### PR TITLE
Allow relative css units to determine width of gridSearch inputs

### DIFF
--- a/inst/htmlwidgets/jstreer.js
+++ b/inst/htmlwidgets/jstreer.js
@@ -146,7 +146,6 @@ function gridSearchBoxes(grid, id) {
     `<div id="${id}-searchFields" style="display: inline-block;">`;
   for(var i = 0; i < ncolumns; i++) {
     var column = columns[i];
-	console.log(column.width);
     var w = column.width;
     var style = `width: calc(${w} - 2px); margin: 0 1px;`;
     var input =

--- a/inst/htmlwidgets/jstreer.js
+++ b/inst/htmlwidgets/jstreer.js
@@ -146,8 +146,9 @@ function gridSearchBoxes(grid, id) {
     `<div id="${id}-searchFields" style="display: inline-block;">`;
   for(var i = 0; i < ncolumns; i++) {
     var column = columns[i];
-    var w = column.width - 2;
-    var style = `width: ${w}px; margin: 0 1px;`;
+	console.log(column.width);
+    var w = column.width;
+    var style = `width: calc(${w} - 2px); margin: 0 1px;`;
     var input =
       `<input type="text" name="${i}" value="" style="${style}">`;
     html += input;


### PR DESCRIPTION
Allow relative css units to determine width of gridSearch inputs, as dicussed here:

https://github.com/stla/jsTreeR/issues/19#issuecomment-1788712333
