### PR TITLE
Update jstreer.js

### DIFF
--- a/inst/htmlwidgets/jstreer.js
+++ b/inst/htmlwidgets/jstreer.js
@@ -142,7 +142,7 @@ function setShinyValueCheckedNodes(instance, leavesOnly) {
 function gridSearchBox(index, id) {
   var input =
     `<input type="text" placeholder="Search..." name="${index}" value=""` +
-    `style="width: calc(100% - 2px);" class="${id}-searchField">`;
+    `style="width: calc(100% - 2px);" class="${id}-searchField jstree-SearchField">`;
   return input;
 }
 

--- a/inst/htmlwidgets/jstreer.js
+++ b/inst/htmlwidgets/jstreer.js
@@ -142,7 +142,7 @@ function setShinyValueCheckedNodes(instance, leavesOnly) {
 function gridSearchBox(index, id) {
   var input =
     `<input type="text" placeholder="Search..." name="${index}" value=""` +
-    `style="width: 100%;" class="${id}-searchField">`;
+    `style="width: calc(100% - 2px);" class="${id}-searchField">`;
   return input;
 }
 


### PR DESCRIPTION
@stla this is just a minor change.

I think the search input should not take up the space of the grid separator:

![image](https://github.com/stla/jsTreeR/assets/36849480/a985a259-0a27-4ce0-947c-2b7ccbeeaeb7)

This looks cleaner.