### PR TITLE
Update jstreer.js

### DIFF
--- a/inst/htmlwidgets/jstreer.js
+++ b/inst/htmlwidgets/jstreer.js
@@ -356,7 +356,7 @@ HTMLWidgets.widget({
             if(checkboxes) {
               setShinyValueCheckedNodes(data.instance, leavesOnly);
             }
-            //setShinyValue(data.new_instance); // modif 9/10/2023
+            setShinyValue(data.instance);
           }
         });
 
@@ -372,17 +372,19 @@ HTMLWidgets.widget({
           } // modif 9/10/2023
         });
 
-        $el.on("select_node.jstree", function(e, data) {
-          if(inShiny) {
-            setShinyValue(data.instance, checkboxes);
-          } // modif 9/10/2023
-        });
+/*
+         $el.on("select_node.jstree", function(e, data) {
+           if(inShiny) {
+             setShinyValue(data.instance, checkboxes);
+           } // modif 9/10/2023
+         });
 
-        $el.on("deselect_node.jstree", function(e, data) {
-          if(inShiny) {
-            setShinyValue(data.instance, checkboxes);
-          } // modif 9/10/2023
-        });
+         $el.on("deselect_node.jstree", function(e, data) {
+           if(inShiny) {
+             setShinyValue(data.instance, checkboxes);
+           } // modif 9/10/2023
+         });
+*/
 
         if(!x.checkWithText) {
           $el.on("check_node.jstree", function(e, data) {


### PR DESCRIPTION
Again using changed.jstree event instead of `select_node.jstree` and `deselect_node.jstree` to fix https://github.com/stla/jsTreeR/issues/34

The fix for https://github.com/stla/jsTreeR/issues/16 is not affected